### PR TITLE
Implement IR Schema Validation

### DIFF
--- a/internal/ir/validation.go
+++ b/internal/ir/validation.go
@@ -1,0 +1,344 @@
+package ir
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidationError represents an error found during IR validation
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+// Error implements the error interface for ValidationError
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// Validate checks if the ContractIR is valid and returns a list of validation errors
+func (c *ContractIR) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Validate metadata
+	metadataErrors := c.Metadata.Validate()
+	errors = append(errors, metadataErrors...)
+
+	// Validate functions
+	for i, function := range c.Functions {
+		fieldPrefix := fmt.Sprintf("Functions[%d]", i)
+		functionErrors := function.Validate()
+		for _, err := range functionErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	// Validate events
+	for i, event := range c.Events {
+		fieldPrefix := fmt.Sprintf("Events[%d]", i)
+		eventErrors := event.Validate()
+		for _, err := range eventErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	// Validate errors
+	for i, contractError := range c.Errors {
+		fieldPrefix := fmt.Sprintf("Errors[%d]", i)
+		errorErrors := contractError.Validate()
+		for _, err := range errorErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	// Validate custom types
+	for i, customType := range c.Types {
+		fieldPrefix := fmt.Sprintf("Types[%d]", i)
+		typeErrors := customType.Validate()
+		for _, err := range typeErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}
+
+// Validate checks if the ContractMetadata is valid and returns a list of validation errors
+func (m *ContractMetadata) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Name is required
+	if strings.TrimSpace(m.Name) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Name",
+			Message: "contract name is required",
+		})
+	}
+
+	// Chain is required
+	if strings.TrimSpace(m.Chain) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Chain",
+			Message: "chain identifier is required",
+		})
+	}
+
+	// Validate source info if present
+	if m.Source != nil {
+		sourceErrors := m.Source.Validate()
+		for _, err := range sourceErrors {
+			err.Field = "Source." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}
+
+// Validate checks if the SourceInfo is valid and returns a list of validation errors
+func (s *SourceInfo) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Language is required
+	if strings.TrimSpace(s.Language) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Language",
+			Message: "programming language is required",
+		})
+	}
+
+	return errors
+}
+
+// Validate checks if the Function is valid and returns a list of validation errors
+func (f *Function) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Name is required
+	if strings.TrimSpace(f.Name) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Name",
+			Message: "function name is required",
+		})
+	}
+
+	// Validate inputs
+	for i, input := range f.Inputs {
+		fieldPrefix := fmt.Sprintf("Inputs[%d]", i)
+		inputErrors := input.Validate()
+		for _, err := range inputErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	// Validate outputs
+	for i, output := range f.Outputs {
+		fieldPrefix := fmt.Sprintf("Outputs[%d]", i)
+		outputErrors := output.Validate()
+		for _, err := range outputErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	// Validate state mutability
+	if err := validateStateMutability(f.StateMutability); err != nil {
+		errors = append(errors, ValidationError{
+			Field:   "StateMutability",
+			Message: err.Error(),
+		})
+	}
+
+	// Validate visibility if present
+	if f.Visibility != "" {
+		if err := validateVisibility(f.Visibility); err != nil {
+			errors = append(errors, ValidationError{
+				Field:   "Visibility",
+				Message: err.Error(),
+			})
+		}
+	}
+
+	return errors
+}
+
+// Validate checks if the Event is valid and returns a list of validation errors
+func (e *Event) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Name is required
+	if strings.TrimSpace(e.Name) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Name",
+			Message: "event name is required",
+		})
+	}
+
+	// Validate parameters
+	for i, param := range e.Parameters {
+		fieldPrefix := fmt.Sprintf("Parameters[%d]", i)
+		paramErrors := param.Validate()
+		for _, err := range paramErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}
+
+// Validate checks if the EventParameter is valid and returns a list of validation errors
+func (p *EventParameter) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Name is required
+	if strings.TrimSpace(p.Name) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Name",
+			Message: "parameter name is required",
+		})
+	}
+
+	// Validate type
+	typeErrors := p.Type.Validate()
+	for _, err := range typeErrors {
+		err.Field = "Type." + err.Field
+		errors = append(errors, err)
+	}
+
+	return errors
+}
+
+// Validate checks if the Parameter is valid and returns a list of validation errors
+func (p *Parameter) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Validate type
+	typeErrors := p.Type.Validate()
+	for _, err := range typeErrors {
+		err.Field = "Type." + err.Field
+		errors = append(errors, err)
+	}
+
+	return errors
+}
+
+// Validate checks if the ParameterType is valid and returns a list of validation errors
+func (t *ParameterType) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// BaseType is required
+	if strings.TrimSpace(t.BaseType) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "BaseType",
+			Message: "base type is required",
+		})
+	}
+
+	// If it's an array, validate array size
+	if t.IsArray && t.ArraySize < 0 {
+		errors = append(errors, ValidationError{
+			Field:   "ArraySize",
+			Message: "array size must be non-negative (0 for dynamic arrays)",
+		})
+	}
+
+	// If it's a map, validate key type
+	if t.IsMap && strings.TrimSpace(t.MapKeyType) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "MapKeyType",
+			Message: "map key type is required for maps",
+		})
+	}
+
+	// Validate components if present
+	if len(t.Components) > 0 {
+		for i, component := range t.Components {
+			fieldPrefix := fmt.Sprintf("Components[%d]", i)
+			componentErrors := component.Validate()
+			for _, err := range componentErrors {
+				err.Field = fieldPrefix + "." + err.Field
+				errors = append(errors, err)
+			}
+		}
+	}
+
+	return errors
+}
+
+// Validate checks if the ContractError is valid and returns a list of validation errors
+func (e *ContractError) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Name is required
+	if strings.TrimSpace(e.Name) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Name",
+			Message: "error name is required",
+		})
+	}
+
+	// Validate parameters if present
+	for i, param := range e.Parameters {
+		fieldPrefix := fmt.Sprintf("Parameters[%d]", i)
+		paramErrors := param.Validate()
+		for _, err := range paramErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}
+
+// Validate checks if the CustomType is valid and returns a list of validation errors
+func (t *CustomType) Validate() []ValidationError {
+	var errors []ValidationError
+
+	// Name is required
+	if strings.TrimSpace(t.Name) == "" {
+		errors = append(errors, ValidationError{
+			Field:   "Name",
+			Message: "type name is required",
+		})
+	}
+
+	// Validate fields
+	for i, field := range t.Fields {
+		fieldPrefix := fmt.Sprintf("Fields[%d]", i)
+		fieldErrors := field.Validate()
+		for _, err := range fieldErrors {
+			err.Field = fieldPrefix + "." + err.Field
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}
+
+// validateStateMutability checks if the state mutability is valid
+func validateStateMutability(sm StateMutability) error {
+	switch sm {
+	case Pure, View, Nonpayable, Payable:
+		return nil
+	case "":
+		return fmt.Errorf("state mutability is required")
+	default:
+		return fmt.Errorf("invalid state mutability: %s", sm)
+	}
+}
+
+// validateVisibility checks if the visibility is valid
+func validateVisibility(v Visibility) error {
+	switch v {
+	case External, Public, Internal, Private:
+		return nil
+	default:
+		return fmt.Errorf("invalid visibility: %s", v)
+	}
+}

--- a/internal/ir/validation_test.go
+++ b/internal/ir/validation_test.go
@@ -1,0 +1,416 @@
+package ir
+
+import (
+	"testing"
+)
+
+func TestContractIRValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		contract      ContractIR
+		expectedError bool
+		errorCount    int
+	}{
+		{
+			name: "Valid Contract",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "transfer",
+						StateMutability: Nonpayable,
+						Inputs: []Parameter{
+							{
+								Name: "to",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+							},
+							{
+								Name: "amount",
+								Type: ParameterType{
+									BaseType: "uint256",
+								},
+							},
+						},
+						Outputs: []Parameter{
+							{
+								Type: ParameterType{
+									BaseType: "bool",
+								},
+							},
+						},
+					},
+				},
+				Events: []Event{
+					{
+						Name: "Transfer",
+						Parameters: []EventParameter{
+							{
+								Name: "from",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+								Indexed: true,
+							},
+							{
+								Name: "to",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+								Indexed: true,
+							},
+							{
+								Name: "value",
+								Type: ParameterType{
+									BaseType: "uint256",
+								},
+								Indexed: false,
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "Missing Contract Name",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "transfer",
+						StateMutability: Nonpayable,
+						Inputs: []Parameter{
+							{
+								Name: "to",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+							},
+						},
+						Outputs: []Parameter{
+							{
+								Type: ParameterType{
+									BaseType: "bool",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Missing Chain",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name: "TestContract",
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Function",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						// Missing name
+						StateMutability: Nonpayable,
+						Inputs: []Parameter{
+							{
+								Name: "to",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Parameter Type",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "transfer",
+						StateMutability: Nonpayable,
+						Inputs: []Parameter{
+							{
+								Name: "to",
+								Type: ParameterType{
+									// Missing base type
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid State Mutability",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "transfer",
+						StateMutability: "invalid",
+						Inputs: []Parameter{
+							{
+								Name: "to",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Visibility",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "transfer",
+						StateMutability: Nonpayable,
+						Visibility:     "invalid",
+						Inputs: []Parameter{
+							{
+								Name: "to",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Event",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Events: []Event{
+					{
+						// Missing name
+						Parameters: []EventParameter{
+							{
+								Name: "from",
+								Type: ParameterType{
+									BaseType: "address",
+								},
+								Indexed: true,
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Event Parameter",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Events: []Event{
+					{
+						Name: "Transfer",
+						Parameters: []EventParameter{
+							{
+								// Missing name
+								Type: ParameterType{
+									BaseType: "address",
+								},
+								Indexed: true,
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Array Size",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "getArray",
+						StateMutability: View,
+						Outputs: []Parameter{
+							{
+								Type: ParameterType{
+									BaseType:  "uint256",
+									IsArray:   true,
+									ArraySize: -1, // Invalid negative size
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Invalid Map",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					Name:  "TestContract",
+					Chain: "ethereum",
+				},
+				Functions: []Function{
+					{
+						Name:           "getMap",
+						StateMutability: View,
+						Outputs: []Parameter{
+							{
+								Type: ParameterType{
+									BaseType: "uint256",
+									IsMap:    true,
+									// Missing map key type
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    1,
+		},
+		{
+			name: "Multiple Errors",
+			contract: ContractIR{
+				Metadata: ContractMetadata{
+					// Missing name
+					// Missing chain
+				},
+				Functions: []Function{
+					{
+						// Missing name
+						StateMutability: "invalid",
+					},
+				},
+			},
+			expectedError: true,
+			errorCount:    4, // Missing name, chain, function name, invalid state mutability
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := tt.contract.Validate()
+			
+			if tt.expectedError && len(errors) == 0 {
+				t.Errorf("Expected validation errors but got none")
+			}
+			
+			if !tt.expectedError && len(errors) > 0 {
+				t.Errorf("Expected no validation errors but got %d: %v", len(errors), errors)
+			}
+			
+			if tt.expectedError && tt.errorCount > 0 && len(errors) != tt.errorCount {
+				t.Errorf("Expected %d validation errors but got %d: %v", tt.errorCount, len(errors), errors)
+			}
+		})
+	}
+}
+
+func TestStateMutabilityValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutability    StateMutability
+		expectedError bool
+	}{
+		{"Pure", Pure, false},
+		{"View", View, false},
+		{"Nonpayable", Nonpayable, false},
+		{"Payable", Payable, false},
+		{"Empty", "", true},
+		{"Invalid", "invalid", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateStateMutability(tt.mutability)
+			
+			if tt.expectedError && err == nil {
+				t.Errorf("Expected validation error but got none")
+			}
+			
+			if !tt.expectedError && err != nil {
+				t.Errorf("Expected no validation error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestVisibilityValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		visibility    Visibility
+		expectedError bool
+	}{
+		{"External", External, false},
+		{"Public", Public, false},
+		{"Internal", Internal, false},
+		{"Private", Private, false},
+		{"Invalid", "invalid", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVisibility(tt.visibility)
+			
+			if tt.expectedError && err == nil {
+				t.Errorf("Expected validation error but got none")
+			}
+			
+			if !tt.expectedError && err != nil {
+				t.Errorf("Expected no validation error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements validation functions for the IR schema as part of issue #2.

## Changes

- Added `validation.go` with validation methods for all IR structs
- Created comprehensive test suite in `validation_test.go`
- Implemented validation for required fields, type constraints, and relationship integrity

## Implementation Details

- Each struct has its own `Validate()` method that returns a list of validation errors
- Validation errors include both the field path and a descriptive message
- Nested validation is supported (e.g., validating a Function also validates its Parameters)
- Special validation for enums like StateMutability and Visibility

## Testing

All tests are passing, which verifies that the validation logic works correctly for both valid and invalid IR instances.

Closes #2